### PR TITLE
fix: Print `log` crate's loggings correctly through `slog_scope`

### DIFF
--- a/examples/riteraft-memstore/Cargo.toml
+++ b/examples/riteraft-memstore/Cargo.toml
@@ -18,5 +18,6 @@ slog-async = "2"
 slog-term = "2"
 slog = "2"
 slog-stdlog = "4"
+slog-scope = "4.4"
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/examples/riteraft-memstore/src/main.rs
+++ b/examples/riteraft-memstore/src/main.rs
@@ -105,7 +105,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let logger = slog::Logger::root(drain, slog_o!("version" => env!("CARGO_PKG_VERSION")));
 
     // converts log to slog
-    let _log_guard = slog_stdlog::init().unwrap();
+    let _scope_guard = slog_scope::set_global_logger(logger.clone());
+    let _log_guard = slog_stdlog::init_with_level(log::Level::Debug).unwrap();
 
     let options = Options::from_args();
     let store = HashStore::new();


### PR DESCRIPTION
The strings are not all being printed out through the log crate

This PR resolves this through `slog_scope`.

## After

```
🕙 12:43:08 ❯ ./target/debug/riteraft-memstore --raft-addr=0.0.0.0:5011 --web-server=0.0.0.0:8011
Dec 05 03:43:10.919 INFO running in leader mode, version: 0.1.0
Dec 05 03:43:10.920 INFO starting 10 workers, version: 0.1.0
Dec 05 03:43:10.921 INFO switched to configuration, config: Configuration { voters: Configuration { incoming: Configuration { voters: {1} }, outgoing: Configuration { voters: {} } }, learners: {}, learners_next: {}, auto_leave: false }, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.921 DEBG reset election timeout 0 -> 14 at 0, election_elapsed: 0, timeout: 14, prev_timeout: 0, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.921 INFO became follower at term 1, term: 1, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.921 INFO newRaft, peers: Configuration { incoming: Configuration { voters: {1} }, outgoing: Configuration { voters: {} } }, last term: 1, last index: 1, applied: 1, commit: 1, term: 1, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.921 INFO RawNode created with id 1., id: 1, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.921 DEBG reset election timeout 14 -> 16 at 0, election_elapsed: 0, timeout: 16, prev_timeout: 14, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.922 INFO became candidate at term 2, term: 2, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.922 DEBG reset election timeout 16 -> 18 at 0, election_elapsed: 0, timeout: 18, prev_timeout: 16, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.922 INFO became leader at term 2, term: 2, raft_id: 1, version: 0.1.0
Dec 05 03:43:10.922 INFO Actix runtime found; starting in Actix runtime, version: 0.1.0
Dec 05 03:43:10.944 INFO listening gRPC requests on: 0.0.0.0:5011, version: 0.1.0
Dec 05 03:43:11.047 DEBG persisted index 2, raft_id: 1, version: 0.1.0
Dec 05 03:43:11.047 DEBG committing index 2, index: 2, raft_id: 1, version: 0.1.0
```